### PR TITLE
[Fix] 여행 수정 시 메모만 수정해도 수정 가능하도록 변경

### DIFF
--- a/app/src/main/java/com/example/moiz/presentation/editTravelList/EditTravelListViewModel.kt
+++ b/app/src/main/java/com/example/moiz/presentation/editTravelList/EditTravelListViewModel.kt
@@ -42,11 +42,13 @@ import javax.inject.Inject
         viewModelScope.launch { endDate.asFlow().collect { checkValidate() } }
         viewModelScope.launch { color.asFlow().collect { checkValidate() } }
         viewModelScope.launch { currency.asFlow().collect { checkValidate() } }
+        viewModelScope.launch { memo.asFlow().collect { checkValidate() } }
     }
 
     private fun checkValidate() {
         isEnabled.value =
-            (title.value != travelDetail.value?.title) || (startDate.value != travelDetail.value?.start_date) || (endDate.value != travelDetail.value?.end_date) || (color.value != travelDetail.value?.color) || (currency.value != travelDetail.value?.currency)
+            (title.value != travelDetail.value?.title) || (startDate.value != travelDetail.value?.start_date) || (endDate.value != travelDetail.value?.end_date) || (color.value != travelDetail.value?.color) || (currency.value != travelDetail.value?.currency || (memo.value != travelDetail.value?.description))
+
     }
 
     fun setTitle(value: String) {


### PR DESCRIPTION
- 여행 수정 시, 메모만 수정해도 버튼 enable 처리