### PR TITLE
#19 Issue 계산도우미 정산 내역 중앙 정렬 안되는 문제 수정

### DIFF
--- a/app/src/main/res/layout/billing_helper_fragment.xml
+++ b/app/src/main/res/layout/billing_helper_fragment.xml
@@ -89,6 +89,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="40dp"
                 android:layout_marginTop="6dp"
+                android:gravity="center"
                 android:orientation="vertical" />
 
             <TextView


### PR DESCRIPTION
- 계산도우미 정산 내역 중앙 정렬
![p](https://github.com/prography-8th-6team/android/assets/50603005/6c25d637-7797-47e4-9908-4aae26f21da6)
